### PR TITLE
Add support for TYPO3 10 LTS

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,33 +1,22 @@
 risky: true
 
-preset: psr2
+preset: psr12
 
 enabled:
     - alpha_ordered_imports
     - binary_operator_spaces
-    - blank_line_after_opening_tag
     - blank_line_before_return
-    - compact_nullable_typehint
-    - concat_with_spaces
-    - declare_equal_normalize
-    - function_typehint_space
     - hash_to_slash_comment
     - linebreak_after_opening_tag
-    - lowercase_cast
-    - lowercase_static_reference
     - method_separation
     - native_function_casing
-    - new_with_braces
     - no_alias_functions
-    - no_blank_lines_after_class_opening
     - no_blank_lines_after_phpdoc
     - no_empty_comment
     - no_empty_phpdoc
     - no_empty_statement
     - no_extra_block_blank_lines
     - no_extra_consecutive_blank_lines
-    - no_leading_import_slash
-    - no_leading_namespace_whitespace
     - no_multiline_whitespace_around_double_arrow
     - no_multiline_whitespace_before_semicolons
     - no_short_bool_cast
@@ -39,7 +28,6 @@ enabled:
     - no_useless_else
     - no_useless_return
     - no_whitespace_before_comma_in_array
-    - no_whitespace_in_blank_line
     - non_printable_character
     - normalize_index_brace
     - object_operator_without_whitespace
@@ -54,23 +42,19 @@ enabled:
     - phpdoc_trim
     - phpdoc_types
     - phpdoc_var_without_name
-    - return_type_declaration
     - self_accessor
     - short_array_syntax
-    - short_scalar_cast
-    - single_blank_line_before_namespace
     - single_quote
-    - single_trait_insert_per_statement
     - standardize_not_equals
     - trailing_comma_in_multiline_array
     - whitespace_after_comma_in_array
 
 finder:
-    name:
-        - "*.php"
-    exclude:
-        - ".Build"
-        - "doc"
-        - "Resources"
-    not-name:
-        - "ext_emconf.php"
+  name:
+    - "*.php"
+  exclude:
+    - ".Build"
+    - "doc"
+    - "Resources"
+  not-name:
+    - "ext_emconf.php"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,7 @@ jobs:
     fast_finish: true
     allow_failures:
         -   if: type != cron
-            env: TYPO3=9.5.x-dev
-        -   if: type != cron
-            env: TYPO3=8.7.x-dev
+            env: TYPO3=10.4.x-dev
     include:
         - &tests
             stage: 🏃 tests
@@ -68,23 +66,11 @@ jobs:
                     echo;
                     echo;
                     find . -name \*.php ! -path "./.Build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;;
-            php: 7.3
-            env: TYPO3=^9.5
+            php: 7.4
+            env: TYPO3=^10.4
         -   <<: *tests
             php: 7.3
-            env: TYPO3=^8.7
-        -   <<: *tests
-            php: 7.2
-            env: TYPO3=^9.5
-        -   <<: *tests
-            php: 7.2
-            env: TYPO3=^8.7
-        -   <<: *tests
-            php: 7.1
-            env: TYPO3=^8.7
-        -   <<: *tests
-            php: 7.0
-            env: TYPO3=^8.7
+            env: TYPO3=^10.4
 
         -   stage: 🚢 to ter
             if: tag IS present AND env(TYPO3_ORG_USERNAME) IS present AND env(TYPO3_ORG_PASSWORD) IS present
@@ -109,8 +95,8 @@ jobs:
             if: type = push AND branch IN (master, pre-merge) AND env(SONAR_TOKEN) IS present AND fork = false
             git:
                 depth: false
-            php: 7.2
-            env: TYPO3="^8.7 ^9.5"
+            php: 7.3
+            env: TYPO3="^10.4"
             before_script:
                 - mkdir -p .Log/coverage/ .Log/junit/
                 - export TYPO3_PATH_WEB=$PWD/.Build/public
@@ -176,23 +162,11 @@ jobs:
                 - composer config minimum-stability dev
                 - composer config prefer-stable true
                 - composer require --no-progress --no-suggest --no-update typo3/cms-core:"@dev"
-            php: 7.3
-            env: TYPO3=9.5.x-dev
+            php: 7.4
+            env: TYPO3=10.4.x-dev
         -   <<: *dev-tests
             php: 7.3
-            env: TYPO3=8.7.x-dev
-        -   <<: *dev-tests
-            php: 7.2
-            env: TYPO3=9.5.x-dev
-        -   <<: *dev-tests
-            php: 7.2
-            env: TYPO3=8.7.x-dev
-        -   <<: *dev-tests
-            php: 7.1
-            env: TYPO3=8.7.x-dev
-        -   <<: *dev-tests
-            php: 7.0
-            env: TYPO3=8.7.x-dev
+            env: TYPO3=10.4.x-dev
 
         - &lowest-tests
             <<: *dev-tests
@@ -202,38 +176,14 @@ jobs:
                 - composer require --no-progress --no-suggest --no-update typo3/cms-composer-installers:"^1.5 || ^2.0"
                 - composer require --no-progress --no-suggest --prefer-lowest nimut/typo3-complete:"$TYPO3"
                 - git checkout composer.json
-            php: 7.3
-            env: TYPO3=^9.5
+            php: 7.4
+            env: TYPO3=^10.4
+        -   <<: *lowest-tests
+            php: 7.4
+            env: TYPO3=10.4.x-dev
         -   <<: *lowest-tests
             php: 7.3
-            env: TYPO3=9.5.x-dev
+            env: TYPO3=^10.4
         -   <<: *lowest-tests
             php: 7.3
-            env: TYPO3=^8.7
-        -   <<: *lowest-tests
-            php: 7.3
-            env: TYPO3=8.7.x-dev
-        -   <<: *lowest-tests
-            php: 7.2
-            env: TYPO3=^9.5
-        -   <<: *lowest-tests
-            php: 7.2
-            env: TYPO3=9.5.x-dev
-        -   <<: *lowest-tests
-            php: 7.2
-            env: TYPO3=^8.7
-        -   <<: *lowest-tests
-            php: 7.2
-            env: TYPO3=8.7.x-dev
-        -   <<: *lowest-tests
-            php: 7.1
-            env: TYPO3=^8.7
-        -   <<: *lowest-tests
-            php: 7.1
-            env: TYPO3=8.7.x-dev
-        -   <<: *lowest-tests
-            php: 7.0
-            env: TYPO3=^8.7
-        -   <<: *lowest-tests
-            php: 7.0
-            env: TYPO3=8.7.x-dev
+            env: TYPO3=10.4.x-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 
 cache:
     directories:
-        - $HOME/.composer/cache
+        - $HOME/.config/composer/cache
         - $HOME/.sonar/cache
 
 jdk:
@@ -31,7 +31,8 @@ jobs:
             before_install:
                 - if php -i | grep -v TRAVIS_CMD | grep -q xdebug; then phpenv config-rm xdebug.ini; fi
             install:
-                - composer require --no-progress --no-suggest nimut/typo3-complete:"$TYPO3"
+                - composer require --no-progress --no-suggest --no-update nimut/typo3-complete:"$TYPO3"
+                - composer update
                 - git checkout composer.json
             before_script:
                 - mkdir -p .Build/public/typo3conf/ext/
@@ -89,7 +90,7 @@ jobs:
                     echo "Uploading release ${TRAVIS_TAG} to TER";
                     echo;
                     echo;
-                    $HOME/.composer/vendor/bin/ter-client upload t3tags . -u "$TYPO3_ORG_USERNAME" -p "$TYPO3_ORG_PASSWORD" -m "$TAG_MESSAGE";
+                    $HOME/.config/composer/vendor/bin/ter-client upload t3tags . -u "$TYPO3_ORG_USERNAME" -p "$TYPO3_ORG_PASSWORD" -m "$TAG_MESSAGE";
 
         -   stage: ✔ with sonarqube scanner
             if: type = push AND branch IN (master, pre-merge) AND env(SONAR_TOKEN) IS present AND fork = false
@@ -97,6 +98,9 @@ jobs:
                 depth: false
             php: 7.3
             env: TYPO3="^10.4"
+            before_install:
+                - nvm install 12
+                - nvm use 12
             before_script:
                 - mkdir -p .Log/coverage/ .Log/junit/
                 - export TYPO3_PATH_WEB=$PWD/.Build/public
@@ -114,7 +118,8 @@ jobs:
                             echo;
                             echo;
                             git clean -Xdf;
-                            composer require --dev --no-progress --no-suggest nimut/typo3-complete:"$TYPO3";
+                            composer require --dev --no-progress --no-suggest --no-update nimut/typo3-complete:"$TYPO3";
+                            composer update;
                             git checkout composer.json;
                             VERSION=${TYPO3//[!0-9]/};
 
@@ -142,7 +147,8 @@ jobs:
                         echo "Merging log and coverage files";
                         echo;
                         echo;
-                        composer require --no-progress --no-suggest --update-with-all-dependencies nimut/phpunit-merger;
+                        composer require --no-progress --no-suggest --no-update nimut/phpunit-merger;
+                        composer update;
                         .Build/bin/phpunit-merger coverage .Log/coverage/ .Log/coverage.xml;
                         .Build/bin/phpunit-merger log .Log/junit/ .Log/junit.xml;
                     fi
@@ -173,8 +179,8 @@ jobs:
             stage: 🏃 prefer-lowest tests
             if: type = cron
             install:
-                - composer require --no-progress --no-suggest --no-update typo3/cms-composer-installers:"^1.5 || ^2.0"
-                - composer require --no-progress --no-suggest --prefer-lowest nimut/typo3-complete:"$TYPO3"
+                - composer require --no-progress --no-suggest --no-update --prefer-lowest nimut/typo3-complete:"$TYPO3"
+                - composer update
                 - git checkout composer.json
             php: 7.4
             env: TYPO3=^10.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ jobs:
     allow_failures:
         -   if: type != cron
             env: TYPO3=10.4.x-dev
+        -   if: type != cron
+            env: TYPO3=9.5.x-dev
     include:
         - &tests
             stage: 🏃 tests
@@ -70,8 +72,20 @@ jobs:
             php: 7.4
             env: TYPO3=^10.4
         -   <<: *tests
+            php: 7.4
+            env: TYPO3=^9.5
+        -   <<: *tests
             php: 7.3
             env: TYPO3=^10.4
+        -   <<: *tests
+            php: 7.3
+            env: TYPO3=^9.5
+        -   <<: *tests
+            php: 7.2
+            env: TYPO3=^10.4
+        -   <<: *tests
+            php: 7.2
+            env: TYPO3=^9.5
 
         -   stage: 🚢 to ter
             if: tag IS present AND env(TYPO3_ORG_USERNAME) IS present AND env(TYPO3_ORG_PASSWORD) IS present
@@ -96,8 +110,8 @@ jobs:
             if: type = push AND branch IN (master, pre-merge) AND env(SONAR_TOKEN) IS present AND fork = false
             git:
                 depth: false
-            php: 7.3
-            env: TYPO3="^10.4"
+            php: 7.2
+            env: TYPO3="^9.5 ^10.4"
             before_install:
                 - nvm install 12
                 - nvm use 12
@@ -171,8 +185,20 @@ jobs:
             php: 7.4
             env: TYPO3=10.4.x-dev
         -   <<: *dev-tests
+            php: 7.4
+            env: TYPO3=9.5.x-dev
+        -   <<: *dev-tests
             php: 7.3
             env: TYPO3=10.4.x-dev
+        -   <<: *dev-tests
+            php: 7.3
+            env: TYPO3=9.5.x-dev
+        -   <<: *dev-tests
+            php: 7.2
+            env: TYPO3=10.4.x-dev
+        -   <<: *dev-tests
+            php: 7.2
+            env: TYPO3=9.5.x-dev
 
         - &lowest-tests
             <<: *dev-tests
@@ -188,8 +214,32 @@ jobs:
             php: 7.4
             env: TYPO3=10.4.x-dev
         -   <<: *lowest-tests
+            php: 7.4
+            env: TYPO3=^9.5
+        -   <<: *lowest-tests
+            php: 7.4
+            env: TYPO3=9.5.x-dev
+        -   <<: *lowest-tests
             php: 7.3
             env: TYPO3=^10.4
         -   <<: *lowest-tests
             php: 7.3
             env: TYPO3=10.4.x-dev
+        -   <<: *lowest-tests
+            php: 7.3
+            env: TYPO3=^9.5
+        -   <<: *lowest-tests
+            php: 7.3
+            env: TYPO3=9.5.x-dev
+        -   <<: *lowest-tests
+            php: 7.2
+            env: TYPO3=^10.4
+        -   <<: *lowest-tests
+            php: 7.2
+            env: TYPO3=10.4.x-dev
+        -   <<: *lowest-tests
+            php: 7.2
+            env: TYPO3=^9.5
+        -   <<: *lowest-tests
+            php: 7.2
+            env: TYPO3=9.5.x-dev

--- a/Classes/Form/FieldInformation/StaticText.php
+++ b/Classes/Form/FieldInformation/StaticText.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace IchHabRecht\T3tags\Form\FieldInformation;
 
 use TYPO3\CMS\Backend\Form\AbstractNode;
-use TYPO3\CMS\Lang\LanguageService;
+use TYPO3\CMS\Core\Localization\LanguageService;
 
 class StaticText extends AbstractNode
 {

--- a/Classes/Form/Wizard/SuggestWizardReceiver.php
+++ b/Classes/Form/Wizard/SuggestWizardReceiver.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace IchHabRecht\T3tags\Form\Wizard;
 
 use TYPO3\CMS\Backend\Form\Wizard\SuggestWizardDefaultReceiver;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Imaging\Icon;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\StringUtility;
 
 class SuggestWizardReceiver extends SuggestWizardDefaultReceiver
@@ -32,7 +34,7 @@ class SuggestWizardReceiver extends SuggestWizardDefaultReceiver
                 'uid' => $newUid,
             ];
             $pid = null;
-            $settings = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['t3tags'], ['allowed_classes' => false]);
+            $settings = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('t3tags');
             if (!empty($settings['tagPid'])) {
                 $pid = $settings['tagPid'];
             } elseif (!empty($this->allowedPages)) {

--- a/Configuration/TCA/tx_t3tags_tag.php
+++ b/Configuration/TCA/tx_t3tags_tag.php
@@ -51,14 +51,14 @@ return [
     'columns' => [
         'hidden' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
             ],
         ],
         'starttime' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.starttime',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.starttime',
             'config' => [
                 'type' => 'input',
                 'renderType' => 'inputDateTime',
@@ -71,7 +71,7 @@ return [
         ],
         'endtime' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.endtime',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.endtime',
             'config' => [
                 'type' => 'input',
                 'renderType' => 'inputDateTime',

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Generate tag fields for every record type.
 
 **Register a new field using the TagRegistry**
 
-- Add or extend the existing `ext_tables.sql` file to add the fields to the database table
+- Add or extend the `ext_tables.sql` file to add the new tag fields to the database table
 
 ```
 CREATE TABLE tt_content
 (
-    relevant_tags TEXT,
-    content_tags TEXT
+    relevant_tags int(11) DEFAULT '0' NOT NULL,
+    content_tags int(11) DEFAULT '0' NOT NULL
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,17 @@ Generate tag fields for every record type.
 
 **Register a new field using the TagRegistry**
 
-- Add or extend a file in Configuration/TCA/Overrides
+- Add or extend the existing `ext_tables.sql` file to add the fields to the database table
+
+```
+CREATE TABLE tt_content
+(
+    relevant_tags TEXT,
+    content_tags TEXT
+);
+```
+
+- Add or extend a file in `Configuration/TCA/Overrides`
 
 ```
 <?php

--- a/Tests/Functional/Fixtures/Extensions/t3tags_test/ext_emconf.php
+++ b/Tests/Functional/Fixtures/Extensions/t3tags_test/ext_emconf.php
@@ -23,7 +23,7 @@ $EM_CONF[$_EXTKEY] = array (
   array (
     'depends' => 
     array (
-      'typo3' => '8.7.8-9.5.99',
+      'typo3' => '10.4.0-10.4.99',
       't3tags' => '0.1.0',
     ),
     'conflicts' => 

--- a/Tests/Functional/Fixtures/Extensions/t3tags_test/ext_emconf.php
+++ b/Tests/Functional/Fixtures/Extensions/t3tags_test/ext_emconf.php
@@ -18,13 +18,13 @@ $EM_CONF[$_EXTKEY] = array (
   'uploadfolder' => 0,
   'createDirs' => '',
   'clearCacheOnLoad' => 1,
-  'version' => '0.1.3',
+  'version' => '0.2.0',
   'constraints' => 
   array (
     'depends' => 
     array (
-      'typo3' => '10.4.0-10.4.99',
-      't3tags' => '0.1.0',
+      'typo3' => '9.5.0-10.4.99',
+      't3tags' => '1.1.0',
     ),
     'conflicts' => 
     array (

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         }
     ],
     "require": {
-        "php": ">= 7.0, < 7.4",
-        "typo3/cms-core": "^8.7 || ^9.5"
+        "php": ">= 7.3, < 8.0",
+        "typo3/cms-core": "^10.4"
     },
     "require-dev": {
-        "nimut/testing-framework": "4.x-dev"
+        "nimut/testing-framework": "5.x-dev"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         }
     ],
     "require": {
-        "php": ">= 7.3, < 8.0",
-        "typo3/cms-core": "^10.4"
+        "php": ">= 7.2, < 7.5",
+        "typo3/cms-core": "^9.5 || ^10.4"
     },
     "require-dev": {
         "nimut/testing-framework": "5.x-dev"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -22,16 +22,16 @@ $EM_CONF[$_EXTKEY] = array (
   'createDirs' => '',
   'clearCacheOnLoad' => 0,
   'version' => '1.0.1',
-  'constraints' => 
+  'constraints' =>
   array (
-    'depends' => 
+    'depends' =>
     array (
-      'typo3' => '8.7.0-9.5.99',
+      'typo3' => '10.4.0-10.4.99',
     ),
-    'conflicts' => 
+    'conflicts' =>
     array (
     ),
-    'suggests' => 
+    'suggests' =>
     array (
     ),
   ),

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -21,12 +21,12 @@ $EM_CONF[$_EXTKEY] = array (
   'uploadfolder' => 0,
   'createDirs' => '',
   'clearCacheOnLoad' => 0,
-  'version' => '1.0.1',
+  'version' => '1.1.0',
   'constraints' =>
   array (
     'depends' =>
     array (
-      'typo3' => '10.4.0-10.4.99',
+      'typo3' => '9.5.0-10.4.99',
     ),
     'conflicts' =>
     array (


### PR DESCRIPTION
This pull request adds support for TYPO3 10 LTS and current PHP 7.x versions but also drops support for older TYPO3 and unsupported PHP versions.